### PR TITLE
update repo list for custom android_hardware_qcom_display

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -437,7 +437,8 @@
   <project path="hardware/qcom/bt" name="LineageOS/android_hardware_qcom_bt" groups="qcom,pdk-qcom" />
   <project path="hardware/qcom/camera" name="platform/hardware/qcom/camera" groups="qcom_camera,pdk-qcom" remote="aosp" />
   <project path="hardware/qcom/data/ipacfg-mgr" name="LineageOS/android_hardware_qcom_data_ipacfg-mgr" groups="qcom,pdk-qcom" />
-  <project path="hardware/qcom/display" name="LineageOS/android_hardware_qcom_display" groups="pdk-qcom,qcom,qcom_display" />
+  <!-- <project path="hardware/qcom/display" name="LineageOS/android_hardware_qcom_display" groups="pdk-qcom,qcom,qcom_display" /> -->
+  <project path="hardware/qcom/display" name="danielarcher-dev/android_hardware_qcom_display" groups="pdk-qcom,qcom,qcom_display" />
   <project path="hardware/qcom/gps" name="LineageOS/android_hardware_qcom_gps" groups="qcom,qcom_gps,pdk-qcom" />
   <project path="hardware/qcom/keymaster" name="LineageOS/android_hardware_qcom_keymaster" groups="qcom,qcom_keymaster,pdk-qcom" />
   <project path="hardware/qcom/media" name="LineageOS/android_hardware_qcom_media" groups="qcom,pdk-qcom" />


### PR DESCRIPTION
Need to make some changes to android_hardware_qcom_display, LOCAL_CLANG=false not being supported anymore.

eg:
[ 48% 243/496] including hardware/qcom/Android.mk ...
FAILED:
hardware/qcom/display/msm8994/libcopybit/Android.mk: error: copybit.msm8992: LOCAL_CLANG false is no longer supported
build/make/core/binary.mk:417: error: done.
16:02:44 ckati failed with: exit status 1